### PR TITLE
bugfix: lodash.foreach can't exit with obj

### DIFF
--- a/lib/core/center.js
+++ b/lib/core/center.js
@@ -83,9 +83,9 @@ class TaskQueue {
    * @public
    */
   getTaskState(id) {
-    forEach(this.queue, taskObj => {
+    for(let taskObj of this.queue){
       if (id === taskObj.id) return taskObj.state;
-    });
+    }
 
     return 'unknown';
   }
@@ -95,10 +95,10 @@ class TaskQueue {
    * @public
    */
   getResultFile(id) {
-    forEach(this.queue, taskObj => {
+    for(let taskObj of this.queue){
       if (id === taskObj.id) return taskObj.file;
-    });
-
+    }
+    
     return null;
   }
 


### PR DESCRIPTION
bugfix: lodash.foreach can't exit with obj