### PR TITLE
让ffcreator每个节点的初始anchor都是一致的

### DIFF
--- a/lib/node/text.js
+++ b/lib/node/text.js
@@ -30,6 +30,7 @@ class FFText extends FFNode {
   createDisplay() {
     const { text, fontSize = 36, color = '#000000' } = this.conf;
     this.display = new ProxyObj();
+    this.setAnchor(0.5);
     this.display.text = text;
     this.display.updateStyle({ fontSize, fill: color });
   }


### PR DESCRIPTION
ffcreator，image，video anchor都是中心，文档也是中心，text不是，统一下