### PR TITLE
fixed a bug

### DIFF
--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -36,6 +36,7 @@ class FFVideo extends FFImage {
     if (!conf.width)
       FFLogger.error({ pos: 'FFVideo', error: 'This component must enter the width!' });
 
+    this.aProbeCommand = FFmpegUtil.createCommand();
     this.acommand = FFmpegUtil.createCommand();
     this.vcommand = FFmpegUtil.createCommand();
 
@@ -275,11 +276,7 @@ class FFVideo extends FFImage {
     this.parent.addAudio(audio);
   }
 
-  /**
-   * Extract the audio file from the movie
-   * @private
-   */
-  extractAudio() {
+  doExtractAudio() {
     return new Promise((resolve, reject) => {
       const opts =
         this.endTime === DEFAULT_TIME ? [] : ['-ss', this.startTime, '-to', this.endTime];
@@ -304,6 +301,32 @@ class FFVideo extends FFImage {
 
       this.acommand.run();
     });
+  }
+
+  /**
+   * Extract the audio file from the movie
+   * @private
+   */
+  extractAudio() {
+    return new Promise((resolve,reject) => {
+      this.aProbeCommand
+      .addInput(this.getPath())
+      .ffprobe((err, data) => {
+        if(data.streams.find(item=>item.codec_type === 'audio')){
+          FFLogger.info({ pos: 'FFVideo', msg: 'Audio preProcessing completed!' });
+          resolve(this.doExtractAudio())
+        }else{
+          FFLogger.info({ pos: 'FFVideo', msg: 'Audio preProcessing completed! This video has no audio track!' });
+          resolve()
+        }
+
+        if(err){
+          FFLogger.error({ pos: 'FFVideo', msg: 'Audio preProcessing error', error: err });
+          reject(err);
+        }
+      });
+
+    })
   }
 
   /**

--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -258,11 +258,20 @@ class FFVideo extends FFImage {
     if (!this.parent) return;
     if (!this.materials.apath) return;
 
-    const audio = new FFAudio({
+    let audioOption = {
       path: this.materials.apath,
       start: this.getDelayTime(),
-      loop: this.loop,
-    });
+    }
+
+    if(this.loop){
+      audioOption = Object.assign(audioOption,{
+        loop: this.loop,
+        ss: '00:00:00',
+        to: DateUtil.secondsToHms(this.parent.getRealDuration())
+      })
+    }
+    
+    const audio = new FFAudio(audioOption);
     this.parent.addAudio(audio);
   }
 


### PR DESCRIPTION
If the `loop` attribute is set for a `FFVideo`, the sound of this video will be retained in the subsequent scenes when the scene is switched.

**If an `FFAudio` has the `loop` property set, the same problem will occur, but I haven't found a way to get the duration of the scene in `FFAudio`.**