### PR TITLE
修复所有元素透明度

### DIFF
--- a/lib/animate/effects.js
+++ b/lib/animate/effects.js
@@ -61,6 +61,7 @@ const TARGET_ROTATE_LEFT = '_target_rotate_left_';
 const TARGET_ROTATE_LEFT_BIG = '_target_rotate_left_big_';
 const TARGET_ROTATE_RIGHT = '_target_rotate_right_';
 const TARGET_ROTATE_RIGHT_BIG = '_target_rotate_right_big_';
+const TARGET_ALPHA = '_target_alpha_';
 
 /**
  * base props
@@ -86,7 +87,7 @@ const OUTSING = { time: LONG_TIME, delay: DELAY_OUT, type: 'outing' };
  */
 Effects.effects = {
   // Fading In Out
-  fadeIn: { from: { alpha: 0 }, to: { alpha: 1 }, ...INS, ease: 'Linear.None' },
+  fadeIn: { from: { alpha: 0 }, to: TARGET_ALPHA, ...INS, ease: 'Linear.None' },
   fadeOut: { from: { alpha: 1 }, to: { alpha: 0 }, ...OUTS },
   fadeInLeft: ['fadeIn', { ...INS, from: TARGET_LEFT, to: TARGET }],
   fadeInRight: ['fadeIn', { ...INS, from: TARGET_RIGHT, to: TARGET }],
@@ -497,6 +498,11 @@ Effects.getMappingVal = function(fakeVal, obj) {
       break;
     case TARGET_ROTATE_RIGHT_BIG:
       val = { rotation: obj.rotation + MAX_ROT };
+      break;
+
+    // alpha
+    case TARGET_ALPHA:
+      val = { alpha: obj.alpha || 1 };
       break;
   }
 


### PR DESCRIPTION
### 透明度设置在以下代码中无法工作：

![微信截图_20220422144520](https://user-images.githubusercontent.com/20235341/164619810-fe308a75-1ed8-4f12-b5e4-ad9a7eaa4ec5.png)

### 表现为：

![微信截图_20220422145421](https://user-images.githubusercontent.com/20235341/164620511-6800abbf-35fd-40f1-979c-168d2cca08a4.png)

### 修复后：

![微信截图_20220422144339](https://user-images.githubusercontent.com/20235341/164620552-f7b39125-e499-4c1a-923a-26c9830b50b9.png)