### PR TITLE
fix: Add FFPROBE_PATH environment variable for ffmpeg-probe

### DIFF
--- a/lib/utils/ffmpeg.js
+++ b/lib/utils/ffmpeg.js
@@ -39,11 +39,13 @@ const FFmpegUtil = {
   /**
    * Set the installation path of the current server ffprobe.
    * If not set, the ffprobe command of command will be found by default.
-   *
+   * Environment variable FFPROBE_PATH is used in ffmpeg-probe.
+   * 
    * @param {string} path - installation path of the current server ffprobe
    * @public
    */
   setFFprobePath(path) {
+    process.env.FFPROBE_PATH = path;
     ffmpeg.setFfprobePath(path);
   },
 


### PR DESCRIPTION
修复在没有全局安装ffmpeg时，使用ffmpeg-probe获取元数据信息失败的问题