### PR TITLE
fix:修复视频元素不存在音频流时FFmpeg出错的问题

### DIFF
--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -151,7 +151,15 @@ class FFVideo extends FFImage {
     } catch (e) {}
 
     this.resetDurationTime();
-    if (this.audio) await this.extractAudio();
+    if (this.audio){
+      const { streams=[] } = this.materials.info;
+      const hasAudioStream = streams.some(function(stream) {
+        return stream.codec_type === 'audio';
+      });
+      if(hasAudioStream){
+        await this.extractAudio();
+      }
+    };
     await this.extractVideo();
     this.addAudioToScene();
   }


### PR DESCRIPTION
视频元素不存在音频流时FFmpeg会出错，目前是判断视频元素是否存在音频流，存在才会执行extractAudio