### PR TITLE
fix:修复视频元素不存在音频流时FFmpeg出错的问题

### DIFF
--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -151,7 +151,15 @@ class FFVideo extends FFImage {
     } catch (e) {}
 
     this.resetDurationTime();
-    if (this.audio) await this.extractAudio();
+    if (this.audio){
+      const { streams=[] } = this.materials.info;
+      const hasAudioStream = streams.some(function(stream) {
+        return stream.codec_type === 'audio';
+      });
+      if(hasAudioStream){
+        await this.extractAudio();
+      }
+    };
     await this.extractVideo();
     this.addAudioToScene();
   }

--- a/lib/node/video.js
+++ b/lib/node/video.js
@@ -159,7 +159,7 @@ class FFVideo extends FFImage {
       if(hasAudioStream){
         await this.extractAudio();
       }
-    };
+    }
     await this.extractVideo();
     this.addAudioToScene();
   }


### PR DESCRIPTION
视频元素不存在音频流时FFmpeg出错的问题
目前采用的方式是判断是否存在音频流，不存在就不执行相关ffmpeg指令