### PR TITLE
feat: make subtitle good clean

### DIFF
--- a/lib/node/subtitle.js
+++ b/lib/node/subtitle.js
@@ -200,8 +200,8 @@ class FFSubtitle extends FFNode {
 
   setDefaultStyle() {
     const padding = 10;
-    const { color = '#ffffff' } = this.conf;
-    this.setStyle({ color, padding, alpha: 0 });
+    const { color = '#ffffff', stroke = '#000000', strokeThickness = 3 } = this.conf;
+    this.setStyle({ color, padding, alpha: 0, stroke: stroke, strokeThickness: strokeThickness });
   }
 
   async preProcessing() {

--- a/lib/node/subtitle.js
+++ b/lib/node/subtitle.js
@@ -200,8 +200,8 @@ class FFSubtitle extends FFNode {
 
   setDefaultStyle() {
     const padding = 10;
-    const { color = '#ffffff', backgroundColor = '#00219c' } = this.conf;
-    this.setStyle({ color, padding, backgroundColor, alpha: 0 });
+    const { color = '#ffffff' } = this.conf;
+    this.setStyle({ color, padding, alpha: 0 });
   }
 
   async preProcessing() {


### PR DESCRIPTION
* Disable the background of subtitle. If text is added to the video content and incorporated into it, setting the default background is not appropriate
* Support set stroke style for subtitle