### PR TITLE
fix: FFSubtitle's srt format is not synchronized between subtitles an…

### DIFF
--- a/lib/node/subtitle.js
+++ b/lib/node/subtitle.js
@@ -309,12 +309,11 @@ class FFSubtitle extends FFNode {
 
     if (captions.length > 0) {
       forEach(captions, paragraph => {
-        const time = paragraph.duration / 1000;
-        const frames = start + time * fps;
+        const start = paragraph.start / 1000 * fps;
+        const frames = paragraph.end / 1000 * fps;
         const text = paragraph.text;
         console.log(text);
         this.textList.push({ start, frames, text, draw: false });
-        start = frames;
       });
     } else {
       forEach(list, text => {


### PR DESCRIPTION
The start time of the subtitle text cannot be set to 0 by default; instead, it should range from the beginning time to the end time. #416 