### PR TITLE
fix(creator): FFCreatorCenter cannot customize the fileName

### DIFF
--- a/lib/creator.js
+++ b/lib/creator.js
@@ -29,13 +29,16 @@ const Renderer = require('./core/renderer');
 const FFmpegUtil = require('./utils/ffmpeg');
 const Effects = require('./animate/effects');
 const { Application, Loader, settings, destroyAndCleanAllCache } = require('inkpaint');
+const cloneDeep = require('lodash/cloneDeep');
 
 class FFCreator extends FFCon {
+  _userConf
   constructor(conf = {}) {
     super({ type: 'creator', ...conf });
 
     this.audios = [];
     this.inCenter = false;
+    this._userConf = cloneDeep(conf)
     this.conf = new Conf(conf);
     this.loader = new Loader();
     this.destroyed = false;
@@ -98,7 +101,7 @@ class FFCreator extends FFCon {
    */
   generateOutput() {
     const ext = this.getConf('ext');
-    const outputDir = this.getConf('outputDir');
+    const outputDir = this._userConf["outputDir"];
     if (this.inCenter && outputDir) {
       this.setOutput(path.join(outputDir, `${Utils.genUuid()}.${ext}`));
     }


### PR DESCRIPTION
fix https://github.com/tnfe/FFCreator/issues/326

在这个代码中

https://github.com/tnfe/FFCreator/blob/abbbb1104f484278cc61c3be65408f2a6c7cc3a7/lib/conf/conf.js#L48

给outputDir设置了一个默认值，导致了下面的代码每次都会进入 `if (this.inCenter && outputDir)` ，这导致了 output 这个变量永远都会被 uuid 设置，从而用户 实例化的 output永远不生效

https://github.com/tnfe/FFCreator/blob/abbbb1104f484278cc61c3be65408f2a6c7cc3a7/lib/creator.js#L99-L105

