### PR TITLE
feat: Update version of echarts in nodejs v22 to avoid ReferenceError

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@xsstomy/subsrt": "^1.0.0",
     "browser-or-node": "^1.3.0",
     "colors": "^1.4.0",
-    "echarts": "5.1.2",
+    "echarts": "5.5.1",
     "eventemitter3": "^4.0.7",
     "ffmpeg-probe": "^1.0.6",
     "ffprobe-installer": "^2.1.5",


### PR DESCRIPTION

    
    
<img width="975" alt="ReferenceError" src="https://github.com/user-attachments/assets/41c2b3ad-4671-468c-b73c-66cced7b8fe8" />
